### PR TITLE
fix logout - wrong parameters usage on logOut method 

### DIFF
--- a/src/Okta.php
+++ b/src/Okta.php
@@ -180,7 +180,7 @@ class Okta
         // Anybody who gets here should be logged out
         if ($currentMember) {
             Security::setCurrentUser(null);
-            Injector::inst()->get(IdentityStore::class)->logOut($member, true, $this->request);
+            Injector::inst()->get(IdentityStore::class)->logOut($this->request);
         }
 
         return false;


### PR DESCRIPTION
 - cause error 500 on session timeout (method is called with wrong parameters)
 - jira: NSU-203 (https://silverstripe.atlassian.net/secure/RapidBoard.jspa?rapidView=415&projectKey=NSU&modal=detail&selectedIssue=NSU-203)

